### PR TITLE
As optional

### DIFF
--- a/src/NpgsqlFSharpParser/Parser.fs
+++ b/src/NpgsqlFSharpParser/Parser.fs
@@ -245,7 +245,7 @@ let optionalFrom =
     optionalExpr (
         attempt (
             text "FROM " >>. simpleIdentifier >>= fun table ->
-            text "AS" >>= fun _ ->
+            optional (text "AS") >>= fun _ ->
             simpleIdentifier >>= fun alias ->
             preturn (Expr.As(Expr.Ident table, Expr.Ident alias))
         )

--- a/src/NpgsqlFSharpParser/Parser.fs
+++ b/src/NpgsqlFSharpParser/Parser.fs
@@ -3,17 +3,107 @@ module NpgsqlFSharpParser.Parser
 
 open FParsec
 open System
+/// https://www.postgresql.org/docs/13/sql-keywords-appendix.html
+let reserved = [
+    "ALL"
+    "ANALYSE"
+    "ANALYZE"
+    "AND"
+    "ANY"
+    "ARRAY"
+    "AS"
+    "ASC"
+    "ASYMMETRIC"
+    "BOTH"
+    "CASE"
+    "CAST"
+    "CHECK"
+    "COLLATE"
+    "COLUMN"
+    "CONSTRAINT"
+    "CREATE"
+    "DEFAULT"
+    "DESC"
+    "DISTINCT"
+    "DO"
+    "ELSE"
+    "END"
+    "FALSE"
+    "FOR"
+    "FOREIGN"
+    "FROM"
+    "GROUP"
+    "HAVING"
+    "IN"
+    "INNER"
+    "INTERSECT"
+    "INTO"
+    "IS"
+    "ISNULL"
+    "JOIN"
+    "LEADING"
+    "LEFT"
+    "LIMIT"
+    "LOCALTIME"
+    "LOCALTIMESTAMP"
+    "NEW"
+    "NOT"
+    "NULL"
+    "OFF"
+    "OFFSET"
+    "OLD"
+    "ON"
+    "ONLY"
+    "OR"
+    "ORDER"
+    "OUTER"
+    "OVERLAPS"
+    "PLACING"
+    "PRIMARY"
+    "REFERENCES"
+    "RIGHT"
+    "SELECT"
+    "SOME"
+    "SYMMETRIC"
+    "TABLE"
+    "THEN"
+    "TO"
+    "TRUE"
+    "UNION"
+    "UNIQUE"
+    "USER"
+    "USING"
+    "WHEN"
+    "WHERE"
+]
 
-let simpleIdentifier : Parser<string, unit> =
+// Applies popen, then pchar repeatedly until pclose succeeds,
+// returns the string in the middle
+let manyCharsBetween popen pclose pchar = popen >>? manyCharsTill pchar pclose
+
+// Parses any string between popen and pclose
+let anyStringBetween popen pclose = manyCharsBetween popen pclose anyChar
+
+// Cannot be a reserved keyword.
+let stringIdentifier : Parser<string, unit> =
     let isIdentifierFirstChar token = isLetter token
     let isIdentifierChar token = isLetter token || isDigit token || token = '.' || token = '_'
     many1Satisfy2L isIdentifierFirstChar isIdentifierChar "identifier" .>> spaces
+    >>= fun identifier ->
+    if List.contains (identifier.ToUpper()) reserved
+    then fail (sprintf "Identifier %s is a reserved keyword" identifier)
+    else preturn identifier
+
+// Can be a reserved keyword.
+let quotedIdentifier : Parser<string, unit> =
+    (skipChar '\"' |> anyStringBetween <| skipChar '\"')
+
+let simpleIdentifier =
+    quotedIdentifier
+    <|> stringIdentifier
 
 let identifier : Parser<Expr, unit> =
-    let isIdentifierFirstChar token = isLetter token
-    let isIdentifierChar token = isLetter token || isDigit token || token = '.' || token = '_'
-    many1Satisfy2L isIdentifierFirstChar isIdentifierChar "identifier" .>> spaces
-    |>> Expr.Ident
+    simpleIdentifier |>> Expr.Ident
 
 let parameter : Parser<Expr, unit> =
     let isIdentifierFirstChar token = token = '@'
@@ -47,16 +137,9 @@ let boolean : Parser<Expr, unit> =
     (text "true" |>> fun _ -> Expr.Boolean true)
     <|> (text "false" |>> fun _ -> Expr.Boolean false)
 
-// Applies popen, then pchar repeatedly until pclose succeeds,
-// returns the string in the middle
-let manyCharsBetween popen pclose pchar = popen >>? manyCharsTill pchar pclose
-
-// Parses any string between popen and pclose
-let anyStringBetween popen pclose = manyCharsBetween popen pclose anyChar
-
 // Parses any string between double quotes
 let quotedString =
-    (attempt (pstring "''") |>> fun _ -> String.Empty) 
+    (attempt (pstring "''") |>> fun _ -> String.Empty)
     <|> (skipChar '\'' |> anyStringBetween <| skipChar '\'')
 
 let stringLiteral : Parser<Expr, unit> =
@@ -67,7 +150,7 @@ let commaSeparatedExprs = sepBy expr comma
 
 let selections =
     (star |>> List.singleton)
-    <|> (attempt commaSeparatedExprs) 
+    <|> (attempt commaSeparatedExprs)
     <|> (attempt (parens commaSeparatedExprs))
 
 let functionExpr =
@@ -78,7 +161,7 @@ let functionExpr =
     (parens commaSeparatedExprs)
     |>> fun arguments -> Expr.Function(functionName, arguments)
 
-let innerJoin = 
+let innerJoin =
     (attempt (text "INNER JOIN") <|> attempt (text "JOIN")) >>. simpleIdentifier .>> text "ON" >>= fun tableName ->
     expr |>> fun expr -> JoinExpr.InnerJoin(tableName, expr)
 
@@ -123,7 +206,7 @@ let orderByDescNullsFirst =
     parser |>> fun columnName -> Ordering.DescNullsFirst columnName
 
 let orderByDescNullsLast =
-    let parser = attempt (simpleIdentifier .>> text "DESC NULLS LAST") 
+    let parser = attempt (simpleIdentifier .>> text "DESC NULLS LAST")
     parser |>> fun columnName -> Ordering.DescNullsLast columnName
 
 let orderingExpr =
@@ -184,16 +267,16 @@ let optionalGroupBy =
 
 let selectQuery =
     text "SELECT" >>= fun _ ->
-    optionalDistinct >>= fun _ -> 
+    optionalDistinct >>= fun _ ->
     selections >>= fun selections ->
     optionalFrom >>= fun tableName ->
-    joinExpr >>= fun joinExprs -> 
+    joinExpr >>= fun joinExprs ->
     optionalWhereClause >>= fun whereExpr ->
     optionalGroupBy >>= fun groupByExpr ->
     optionalHavingClause >>= fun havingExpr ->
     optionalOrderingExpr >>= fun orderingExprs ->
     optionalLimit >>= fun limitExpr ->
-    optionalOffset >>= fun offsetExpr -> 
+    optionalOffset >>= fun offsetExpr ->
         let query =
             { SelectExpr.Default with
                 Columns = selections
@@ -228,7 +311,7 @@ let insertQuery =
     (parens (sepBy1 expr comma)) >>= fun values ->
     optionalRetuningExpr >>= fun returningExpr ->
         let query = {
-            InsertExpr.Default with 
+            InsertExpr.Default with
                 Table = tableName
                 Columns = columns
                 Values = values
@@ -250,7 +333,7 @@ let updateQuery =
                 Returning = returningExpr
                 Assignments = assignments
         }
-        
+
         preturn (Expr.UpdateQuery query)
 
 opp.AddOperator(InfixOperator("AND", spaces, 7, Associativity.Left, fun left right -> Expr.And(left, right)))
@@ -289,7 +372,7 @@ opp.TermParser <- choice [
 
 let fullParser = (optional spaces) >>. expr .>> (optional spaces <|> (text ";" |>> fun _ -> ()))
 
-let parse (input: string) : Result<Expr, string> = 
+let parse (input: string) : Result<Expr, string> =
     match run fullParser input with
     | Success(result,_,_) -> Result.Ok result
     | Failure(errMsg,_,_) -> Result.Error errMsg

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -124,6 +124,12 @@ let selectQueryTests = testList "Parse SELECT tests" [
             From = Some (Expr.As(Expr.Ident "users", Expr.Ident "u"))
     }
 
+    testSelect "SELECT COUNT(*) AS user_count FROM users u" {
+        SelectExpr.Default with
+            Columns = [Expr.As(Expr.Function("COUNT", [Expr.Star]), Expr.Ident("user_count")) ]
+            From = Some (Expr.As(Expr.Ident "users", Expr.Ident "u"))
+    }
+
     testSelect "SELECT COUNT(*) FROM users LIMIT 10" {
         SelectExpr.Default with
             Columns = [Expr.Function("COUNT", [Expr.Star]) ]

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -69,37 +69,43 @@ let selectQueryTests = testList "Parse SELECT tests" [
     testSelect "SELECT username, user_id FROM users" {
         SelectExpr.Default with
             Columns = [Expr.Ident "username"; Expr.Ident "user_id"]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
+    }
+
+    testSelect """SELECT * FROM "from" """ {
+        SelectExpr.Default with
+            Columns = [Expr.Star]
+            From = Some (Expr.Ident "from")
     }
 
     testSelect "SELECT * FROM users" {
         SelectExpr.Default with
             Columns = [Expr.Star]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
     }
 
     testSelect "SELECT DISTINCT username, user_id FROM users" {
         SelectExpr.Default with
             Columns = [Expr.Ident "username"; Expr.Ident "user_id"]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
     }
 
     testSelect "SELECT DISTINCT ON (username, user_id) FROM users" {
         SelectExpr.Default with
             Columns = [Expr.Ident "username"; Expr.Ident "user_id"]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
     }
 
     testSelect "SELECT COUNT(*) FROM users" {
         SelectExpr.Default with
             Columns = [Expr.Function("COUNT", [Expr.Star]) ]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
     }
 
     testSelect "SELECT COUNT(*) AS user_count FROM users" {
         SelectExpr.Default with
             Columns = [Expr.As(Expr.Function("COUNT", [Expr.Star]), Expr.Ident("user_count")) ]
-            From = Some (Expr.Ident "users") 
+            From = Some (Expr.Ident "users")
     }
 
     testSelect "SELECT ename || empno AS EmpDetails, COALESCE(comm,0) AS TOTALSAL FROM sales" {
@@ -115,7 +121,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
     testSelect "SELECT COUNT(*) AS user_count FROM users as u" {
         SelectExpr.Default with
             Columns = [Expr.As(Expr.Function("COUNT", [Expr.Star]), Expr.Ident("user_count")) ]
-            From = Some (Expr.As(Expr.Ident "users", Expr.Ident "u")) 
+            From = Some (Expr.As(Expr.Ident "users", Expr.Ident "u"))
     }
 
     testSelect "SELECT COUNT(*) FROM users LIMIT 10" {


### PR DESCRIPTION
## Proposed Changes

The AS keyword is optional noise. See 7.2.1.2 (https://www.postgresql.org/docs/13/queries-table-expressions.html). The PR depends on  #28 .

## Types of changes

What types of changes does your code introduce to BinaryDefense.FSharp.Analyzers?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
