### PR TITLE
Fix parsing of  quoted `schema.table.column` references and comments

### DIFF
--- a/src/NpgsqlFSharpParser/Parser.fs
+++ b/src/NpgsqlFSharpParser/Parser.fs
@@ -86,8 +86,6 @@ let manyCharsBetween popen pclose pchar = popen >>? manyCharsTill pchar pclose
 // Parses any string between popen and pclose
 let anyStringBetween popen pclose = manyCharsBetween popen pclose anyChar
 
-let skipBetween popen pclose = popen >>? skipManyTill skipAnyChar pclose
-
 // Cannot be a reserved keyword.
 let unquotedIdentifier : Parser<string, unit> =
     let isIdentifierFirstChar token = isLetter token

--- a/src/NpgsqlFSharpParser/Parser.fs
+++ b/src/NpgsqlFSharpParser/Parser.fs
@@ -109,15 +109,15 @@ let simpleIdentifier =
     attempt(
         stringIdentifier >>= fun schema ->
         text "." >>. stringIdentifier >>= fun table ->
-        text "." >>. stringIdentifier .>> spaces >>= fun column ->
+        text "." >>. stringIdentifier >>= fun column ->
         preturn (sprintf "%s.%s.%s" schema table column))
     <|>
     attempt(
         stringIdentifier >>= fun table ->
-        text "." >>. stringIdentifier .>> spaces >>= fun column ->
+        text "." >>. stringIdentifier >>= fun column ->
         preturn (sprintf "%s.%s" table column))
     <|>
-    stringIdentifier
+    attempt stringIdentifier
 
 let identifier : Parser<Expr, unit> =
     simpleIdentifier |>> Expr.Ident
@@ -261,14 +261,14 @@ let optionalHavingClause = optionalExpr (text "HAVING" >>. expr)
 let optionalFrom =
     optionalExpr (
         attempt (
-            text "FROM " >>. (parens selectQuery) >>= fun subQuery ->
+            text "FROM" >>. (parens selectQuery) >>= fun subQuery ->
             optional (text "AS") >>= fun _ ->
             simpleIdentifier >>= fun alias ->
             preturn (Expr.As(subQuery, Expr.Ident alias))
         )
         <|>
         attempt (
-            text "FROM " >>. simpleIdentifier >>= fun table ->
+            text "FROM" >>. simpleIdentifier >>= fun table ->
             optional (text "AS") >>= fun _ ->
             simpleIdentifier >>= fun alias ->
             preturn (Expr.As(Expr.Ident table, Expr.Ident alias))

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -427,6 +427,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
 
             Offset = Some (Expr.Integer 100)
     }
+
     testSelect """
         SELECT *
         FROM (SELECT NOW()) AS time
@@ -440,4 +441,44 @@ let selectQueryTests = testList "Parse SELECT tests" [
             }, Expr.Ident "time"))
             Limit = Some (Expr.Integer 1)
     }
+
+    testSelect """
+        SELECT "username" FROM "users"
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Ident "username"]
+            From = Expr.Ident "users" |> Some
+        }
+
+    testSelect """
+        SELECT "username" as "name" FROM "users"
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.As(Expr.Ident "username", Expr.Ident "name") ]
+            From = Expr.Ident "users" |> Some
+        }
+
+    testSelect """
+        SELECT "$Table"."timestamp" FROM "$Table"
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.Ident("$Table.timestamp") ]
+            From = Expr.Ident "$Table" |> Some
+        }
+
+    testSelect """
+        SELECT "$Table".timestamp as ts FROM "$Table"
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.As(Expr.Ident("$Table.timestamp"), Expr.Ident("ts")) ]
+            From = Expr.Ident "$Table" |> Some
+        }
+
+    testSelect """
+        SELECT public."$Table"."timestamp" FROM "$Table"
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.Ident("public.$Table.timestamp") ]
+            From = Expr.Ident "$Table" |> Some
+        }
 ]


### PR DESCRIPTION
## Proposed Changes

Add support for quoted column references in SELECT statements e.g:

```sql
SELECT "username" FROM "users"
```

Add support for  [correlation (see 4.2.1)](https://www.postgresql.org/docs/13/sql-expressions.html) quoted column references e.g:

```sql
SELECT "$Table"."timestamp" FROM "$Table"
```

and mixed quoted/unquoted column references e.g:

```sql
SELECT public."$Table"."timestamp" FROM "$Table"
```

The change keeps the identifiers as a string thus having quoted schema/table/column names containing dots (`.`) will most likely give unexpected behavior. But this makes the change non-breaking by keeping the format of identifiers compatible with before i.e `schema.table.column` as a string.

Also add support for comments, both `/* .. */` and `-- ...`. 

## Types of changes

What types of changes does your code introduce to BinaryDefense.FSharp.Analyzers?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
