### PR TITLE
Add support for timestamp, date, set and declare cursor

### DIFF
--- a/src/NpgsqlFSharpParser/Types.fs
+++ b/src/NpgsqlFSharpParser/Types.fs
@@ -10,6 +10,8 @@ type Expr =
     | StringLiteral of string
     | Integer of int
     | Float of float
+    | Date of string
+    | Timestamp of string
     | Function of name:string * arguments:Expr list
     | And of left:Expr * right:Expr
     | Or of left:Expr * right:Expr
@@ -29,6 +31,8 @@ type Expr =
     | DeleteQuery of expr:DeleteExpr
     | InsertQuery of expr: InsertExpr
     | UpdateQuery of expr: UpdateExpr
+    | SetQuery of expr: SetExpr
+    | DeclareQuery of expr: DeclareExpr
 
 type Ordering =
     | Asc of columnName:string
@@ -110,3 +114,32 @@ type InsertExpr = {
             ConflictResolution = [ ]
             Returning = [ ]
         }
+
+type Scope =
+    | Local
+    | Session
+
+type SetExpr = {
+    Parameter: string
+    Value: Expr option
+    Scope: Scope
+} with
+    static member Default =
+        {
+            Parameter = "";
+            Value = None
+            Scope = Session
+        }
+
+type CursorDeclaration = {
+    Parameter: string
+    Query: Expr
+} with
+    static member Default =
+        {
+            Parameter = "";
+            Query = Expr.Null
+        }
+
+type DeclareExpr =
+    | Cursor of CursorDeclaration

--- a/src/NpgsqlFSharpParser/Types.fs
+++ b/src/NpgsqlFSharpParser/Types.fs
@@ -1,40 +1,9 @@
 namespace rec NpgsqlFSharpParser
 
 [<RequireQualifiedAccess>]
-type DataType =
-    | Integer
-    | BigInt
-    | SmallInt
-    | Real
-    | Double
-    | Array of dataType:DataType * size:int option
-
-    static member TryFromString(valueType: string, ?isArray: bool, ?n: int) : DataType option =
-        let dType =
-            match valueType.ToUpper () with
-            | "INT2"
-            | "SMALLINT" -> Some SmallInt
-            | "INT"
-            | "INT4"
-            | "INTEGER" -> Some Integer
-            | "INT8"
-            | "BIGINT" -> Some BigInt
-            | "FLOAT4"
-            | "REAL" -> Some Real
-            | "FLOAT8"
-            | "DOUBLE PRECISION" -> Some Double
-            | _ -> None
-
-        let isArray = isArray |> Option.bind (function | false -> None | _ -> Some true)
-
-        dType
-        |> Option.bind (fun t -> isArray |> Option.map (fun _ -> Array(dataType=t, size=None)))
-        |> Option.orElse dType
-
-
-[<RequireQualifiedAccess>]
 type Expr =
     | Array of Expr list
+    | List of Expr list
     | Null
     | Star
     | Ident of string
@@ -42,7 +11,10 @@ type Expr =
     | Boolean of bool
     | StringLiteral of string
     | Integer of int
+    | BigInt of int64
+    | SmallInt of int16
     | Float of float
+    | Double of double
     | Date of string
     | Timestamp of string
     | Function of name:string * arguments:Expr list
@@ -178,3 +150,34 @@ type CursorDeclaration = {
 
 type DeclareExpr =
     | Cursor of CursorDeclaration
+
+[<RequireQualifiedAccess>]
+type DataType =
+    | Integer
+    | BigInt
+    | SmallInt
+    | Real
+    | Double
+    | Array of dataType:DataType * size:int option
+
+    static member TryFromString(valueType: string, ?isArray: bool, ?arraySize: int) : DataType option =
+        let dType =
+            match valueType.ToUpper () with
+            | "INT2"
+            | "SMALLINT" -> Some SmallInt
+            | "INT"
+            | "INT4"
+            | "INTEGER" -> Some Integer
+            | "INT8"
+            | "BIGINT" -> Some BigInt
+            | "FLOAT4"
+            | "REAL" -> Some Real
+            | "FLOAT8"
+            | "DOUBLE PRECISION" -> Some Double
+            | _ -> None
+
+        let isArray = isArray |> Option.bind (function | false -> None | _ -> Some true) // Note: Some false -> None.
+
+        dType
+        |> Option.bind (fun t -> isArray |> Option.map (fun _ -> Array(dataType=t, size=arraySize)))
+        |> Option.orElse dType

--- a/src/NpgsqlFSharpParser/Types.fs
+++ b/src/NpgsqlFSharpParser/Types.fs
@@ -10,11 +10,8 @@ type Expr =
     | Parameter of string
     | Boolean of bool
     | StringLiteral of string
-    | Integer of int
-    | BigInt of int64
-    | SmallInt of int16
+    | Integer of int64
     | Float of float
-    | Double of double
     | Date of string
     | Timestamp of string
     | Function of name:string * arguments:Expr list

--- a/src/NpgsqlFSharpParser/Types.fs
+++ b/src/NpgsqlFSharpParser/Types.fs
@@ -1,7 +1,40 @@
 namespace rec NpgsqlFSharpParser
 
 [<RequireQualifiedAccess>]
+type DataType =
+    | Integer
+    | BigInt
+    | SmallInt
+    | Real
+    | Double
+    | Array of dataType:DataType * size:int option
+
+    static member TryFromString(valueType: string, ?isArray: bool, ?n: int) : DataType option =
+        let dType =
+            match valueType.ToUpper () with
+            | "INT2"
+            | "SMALLINT" -> Some SmallInt
+            | "INT"
+            | "INT4"
+            | "INTEGER" -> Some Integer
+            | "INT8"
+            | "BIGINT" -> Some BigInt
+            | "FLOAT4"
+            | "REAL" -> Some Real
+            | "FLOAT8"
+            | "DOUBLE PRECISION" -> Some Double
+            | _ -> None
+
+        let isArray = isArray |> Option.bind (function | false -> None | _ -> Some true)
+
+        dType
+        |> Option.bind (fun t -> isArray |> Option.map (fun _ -> Array(dataType=t, size=None)))
+        |> Option.orElse dType
+
+
+[<RequireQualifiedAccess>]
 type Expr =
+    | Array of Expr list
     | Null
     | Star
     | Ident of string
@@ -20,7 +53,9 @@ type Expr =
     | StringConcat of left:Expr * right:Expr
     | JsonIndex of left:Expr * right:Expr
     | TypeCast of left:Expr * right:Expr
+    | DataType of DataType
     | Not of expr:Expr
+    | Any of expr:Expr
     | Equals of left:Expr * right:Expr
     | GreaterThan of left:Expr * right:Expr
     | LessThan of left:Expr * right:Expr

--- a/tests/NpgsqlFSharpAnalyzer.Tests/NpgsqlFSharpAnalyzer.Tests.fsproj
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/NpgsqlFSharpAnalyzer.Tests.fsproj
@@ -10,6 +10,8 @@
         <Compile Include="ParseInsertTests.fs" />
         <Compile Include="ParseDeleteTests.fs" />
         <Compile Include="ParseSelectTests.fs" />
+        <Compile Include="ParseSetTests.fs" />
+        <Compile Include="ParseDeclareTests.fs" />
         <Compile Include="AssemblyInfo.fs" />
         <Compile Include="Analyzer.fs" />
         <Compile Include="Tests.fs" />

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseDeclareTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseDeclareTests.fs
@@ -1,0 +1,36 @@
+module ParseDeclareTests
+
+open Expecto
+open NpgsqlFSharpParser
+
+let testDeclare inputQuery expected =
+    test inputQuery {
+        match Parser.parse inputQuery with
+        | Ok (Expr.DeclareQuery query) ->
+            Expect.equal query expected "The query is parsed correctly"
+        | Ok somethingElse ->
+            failwithf "Unexpected declare statement %A" somethingElse
+        | Error errorMsg ->
+            failwith errorMsg
+    }
+
+let ftestDeclare inputQuery expected =
+    ftest inputQuery {
+        match Parser.parse inputQuery with
+        | Ok (Expr.DeclareQuery query) ->
+            Expect.equal query expected "The query is parsed correctly"
+        | Ok somethingElse ->
+            failwithf "Unexpected declare statement %A" somethingElse
+        | Error errorMsg ->
+            failwith errorMsg
+    }
+
+[<Tests>]
+let declareQueryTests = testList "Parse DECLARE tests" [
+
+    ftestDeclare "DECLARE c1 CURSOR FOR SELECT NOW();" ({
+        Parameter = "c1"
+        Query = Expr.SelectQuery { SelectExpr.Default with Columns = [Expr.Function("NOW", [])] }
+    } |> Cursor)
+]
+

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseDeclareTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseDeclareTests.fs
@@ -27,8 +27,7 @@ let ftestDeclare inputQuery expected =
 
 [<Tests>]
 let declareQueryTests = testList "Parse DECLARE tests" [
-
-    ftestDeclare "DECLARE c1 CURSOR FOR SELECT NOW();" ({
+    testDeclare "DECLARE c1 CURSOR FOR SELECT NOW();" ({
         Parameter = "c1"
         Query = Expr.SelectQuery { SelectExpr.Default with Columns = [Expr.Function("NOW", [])] }
     } |> Cursor)

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -557,4 +557,44 @@ let selectQueryTests = testList "Parse SELECT tests" [
                     Columns = [Expr.Function ("NOW", [])]
             }, Expr.Ident "time"))
             Limit = Some (Expr.Integer 1)
-    }]
+    }
+
+    testSelect """
+        SELECT
+        COUNT(*)
+        FROM users
+        WHERE last_login > TIMESTAMP '2021-01-04 00:00:00'
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Function("COUNT", [Expr.Star]) ]
+            From = Some (Expr.Ident "users")
+            Where = Some (Expr.GreaterThan(Expr.Ident "last_login", Expr.Timestamp("2021-01-04 00:00:00")))
+    }
+
+    testSelect """
+        SELECT
+        COUNT(*)
+        FROM users
+        WHERE last_login > DATE '2021-01-04 00:00:00'
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Function("COUNT", [Expr.Star]) ]
+            From = Some (Expr.Ident "users")
+            Where = Some (Expr.GreaterThan(Expr.Ident "last_login", Expr.Date("2021-01-04 00:00:00")))
+    }
+
+    testSelect """
+        select timestamp '2021-01-04 00:00:00'
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Timestamp("2021-01-04 00:00:00") ]
+    }
+
+    testSelect """
+        select date '2021-01-04 00:00:00'
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Date("2021-01-04 00:00:00") ]
+    }
+]
+

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -39,11 +39,11 @@ let selectQueryTests = testList "Parse SELECT tests" [
     }
 
     testSelect "SELECT 1" {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect "SELECT 36109712494634" {
-        SelectExpr.Default with Columns = [Expr.BigInt 36109712494634L]
+        SelectExpr.Default with Columns = [Expr.Integer 36109712494634L]
     }
 
     testSelect "SELECT ''" {
@@ -51,7 +51,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
     }
 
     testSelect "SELECT 1::text" {
-        SelectExpr.Default with Columns = [Expr.TypeCast(Expr.Integer 1, Expr.Ident "text")]
+        SelectExpr.Default with Columns = [Expr.TypeCast(Expr.Integer 1L, Expr.Ident "text")]
     }
 
     testSelect "SELECT @input::text, value::ltree" {
@@ -121,7 +121,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
         SelectExpr.Default with
             Columns = [
                 Expr.As(Expr.StringConcat(Expr.Ident "ename", Expr.Ident "empno"), Expr.Ident "EmpDetails")
-                Expr.As(Expr.Function("COALESCE", [ Expr.Ident "comm"; Expr.Integer 0 ]), Expr.Ident "TOTALSAL")
+                Expr.As(Expr.Function("COALESCE", [ Expr.Ident "comm"; Expr.Integer 0L ]), Expr.Ident "TOTALSAL")
             ]
 
             From = Some (Expr.Ident "sales")
@@ -143,7 +143,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
         SelectExpr.Default with
             Columns = [Expr.Function("COUNT", [Expr.Star]) ]
             From = Some (Expr.Ident "users")
-            Limit = Some(Expr.Integer 10)
+            Limit = Some(Expr.Integer 10L)
     }
 
     testSelect "SELECT COUNT(*) FROM users LIMIT @numberOfRows" {
@@ -280,7 +280,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
         SelectExpr.Default with
             Columns = [Expr.Ident "username"; Expr.Ident "email"]
             From = Some (Expr.Ident "users")
-            Where = Some (Expr.In(Expr.Ident "user_id", Expr.List([Expr.Integer 1; Expr.Integer 2;  Expr.Integer 3])))
+            Where = Some (Expr.In(Expr.Ident "user_id", Expr.List([Expr.Integer 1L; Expr.Integer 2L;  Expr.Integer 3L])))
     }
 
     testSelect """
@@ -411,7 +411,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
 
             Having = Some(Expr.GreaterThan(Expr.Function("SUM", [Expr.Ident "amount"]), Expr.Ident "users.salary"))
 
-            Limit = Some (Expr.Integer 20)
+            Limit = Some (Expr.Integer 20L)
     }
 
     testSelect """
@@ -443,9 +443,9 @@ let selectQueryTests = testList "Parse SELECT tests" [
 
             Having = Some(Expr.GreaterThan(Expr.Function("SUM", [Expr.Ident "amount"]), Expr.Ident "users.salary"))
 
-            Limit = Some (Expr.Integer 20)
+            Limit = Some (Expr.Integer 20L)
 
-            Offset = Some (Expr.Integer 100)
+            Offset = Some (Expr.Integer 100L)
     }
 
     testSelect """
@@ -459,7 +459,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
                 SelectExpr.Default with
                     Columns = [Expr.Function ("NOW", [])]
             }, Expr.Ident "time"))
-            Limit = Some (Expr.Integer 1)
+            Limit = Some (Expr.Integer 1L)
     }
 
     testSelect """
@@ -474,7 +474,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
                 SelectExpr.Default with
                     Columns = [Expr.Function ("NOW", [])]
             }, Expr.Ident "time"))
-            Limit = Some (Expr.Integer 1)
+            Limit = Some (Expr.Integer 1L)
     }
 
     testSelect """
@@ -531,37 +531,37 @@ let selectQueryTests = testList "Parse SELECT tests" [
         SelectExpr.Default with
             Columns = [ Expr.Ident("public.$Table.timestamp") ]
             From = Expr.As(Expr.Ident "$Table", Expr.Ident "tbl") |> Some
-            Limit = Some (Expr.Integer 100)
+            Limit = Some (Expr.Integer 100L)
         }
 
     testSelect "SELECT 1 -- This is a comment" {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect """
         -- This is a comment
         SELECT 1""" {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect """
         /* Comment inserted first */
         SELECT 1""" {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect """
         SELECT 1
         /* Comment inserted last */
         """ {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect """
         SELECT 1;
         /* Comment inserted after semicolon */
         """ {
-        SelectExpr.Default with Columns = [Expr.Integer 1]
+        SelectExpr.Default with Columns = [Expr.Integer 1L]
     }
 
     testSelect """
@@ -576,7 +576,7 @@ let selectQueryTests = testList "Parse SELECT tests" [
                 SelectExpr.Default with
                     Columns = [Expr.Function ("NOW", [])]
             }, Expr.Ident "time"))
-            Limit = Some (Expr.Integer 1)
+            Limit = Some (Expr.Integer 1L)
     }
 
     testSelect """

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -33,6 +33,11 @@ let selectQueryTests = testList "Parse SELECT tests" [
             Columns = [Expr.Function("NOW", [])]
     }
 
+    testSelect "SELECT (NOW())" {
+        SelectExpr.Default with
+            Columns = [Expr.Function("NOW", [])]
+    }
+
     testSelect "SELECT 1" {
         SelectExpr.Default with Columns = [Expr.Integer 1]
     }
@@ -595,6 +600,46 @@ let selectQueryTests = testList "Parse SELECT tests" [
     """ {
         SelectExpr.Default with
             Columns = [Expr.Date("2021-01-04 00:00:00") ]
+    }
+
+    testSelect """
+        SELECT * FROM users WHERE id = ANY ('{12378169571900,36109712494634,54795035045033}'::bigint[])
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.Star ]
+            From = Some (Expr.Ident "users")
+            Where =
+                Some(
+                    Expr.Equals(
+                        Expr.Ident "id",
+                        Expr.Any(
+                            Expr.TypeCast(
+                                Expr.StringLiteral "{12378169571900,36109712494634,54795035045033}",
+                                Expr.DataType(DataType.Array(DataType.BigInt, None))
+                            )
+                        )
+                    )
+                )
+    }
+
+    testSelect """
+        SELECT * FROM users WHERE id = ANY ('{1.1,361097124946,34,54795035045033.34}'::double precision[])
+    """ {
+        SelectExpr.Default with
+            Columns = [ Expr.Star ]
+            From = Some (Expr.Ident "users")
+            Where =
+                Some(
+                    Expr.Equals(
+                        Expr.Ident "id",
+                        Expr.Any(
+                            Expr.TypeCast(
+                                Expr.StringLiteral "{1.1,361097124946,34,54795035045033.34}",
+                                Expr.DataType(DataType.Array(DataType.Double, None))
+                            )
+                        )
+                    )
+                )
     }
 ]
 

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSelectTests.fs
@@ -42,6 +42,10 @@ let selectQueryTests = testList "Parse SELECT tests" [
         SelectExpr.Default with Columns = [Expr.Integer 1]
     }
 
+    testSelect "SELECT 36109712494634" {
+        SelectExpr.Default with Columns = [Expr.BigInt 36109712494634L]
+    }
+
     testSelect "SELECT ''" {
         SelectExpr.Default with Columns = [Expr.StringLiteral ""]
     }
@@ -266,6 +270,17 @@ let selectQueryTests = testList "Parse SELECT tests" [
                     From = Some (Expr.Ident "user_ids")
                     Where = Some(Expr.Not(Expr.Equals(Expr.Null, Expr.Ident "id")))
             }))
+    }
+
+    testSelect """
+        SELECT username, email
+        FROM users
+        WHERE user_id IN (1, 2, 3)
+    """ {
+        SelectExpr.Default with
+            Columns = [Expr.Ident "username"; Expr.Ident "email"]
+            From = Some (Expr.Ident "users")
+            Where = Some (Expr.In(Expr.Ident "user_id", Expr.List([Expr.Integer 1; Expr.Integer 2;  Expr.Integer 3])))
     }
 
     testSelect """

--- a/tests/NpgsqlFSharpAnalyzer.Tests/ParseSetTests.fs
+++ b/tests/NpgsqlFSharpAnalyzer.Tests/ParseSetTests.fs
@@ -1,0 +1,43 @@
+module ParseSetTests
+
+open Expecto
+open NpgsqlFSharpParser
+
+let testSet inputQuery expected =
+    test inputQuery {
+        match Parser.parse inputQuery with
+        | Ok (Expr.SetQuery query) ->
+            Expect.equal query expected "The query is parsed correctly"
+        | Ok somethingElse ->
+            failwithf "Unexpected set statement %A" somethingElse
+        | Error errorMsg ->
+            failwith errorMsg
+    }
+
+let ftestSet inputQuery expected =
+    ftest inputQuery {
+        match Parser.parse inputQuery with
+        | Ok (Expr.SetQuery query) ->
+            Expect.equal query expected "The query is parsed correctly"
+        | Ok somethingElse ->
+            failwithf "Unexpected set statement %A" somethingElse
+        | Error errorMsg ->
+            failwith errorMsg
+    }
+
+[<Tests>]
+let setQueryTests = testList "Parse SET tests" [
+
+    testSet "SET DateStyle = ISO" {
+        SetExpr.Default with
+            Parameter = "DateStyle"
+            Value = Some (Expr.Ident "ISO")
+    }
+
+    testSet "SET timezone TO 'Europe/Rome'" {
+        SetExpr.Default with
+            Parameter = "timezone"
+            Value = Some (Expr.StringLiteral "Europe/Rome")
+    }
+]
+


### PR DESCRIPTION
## Proposed Changes

Add support for:

- Timestamp
- Date
- SET expressions
- DECLARE expressions
- ANY operator
- Datatypes. E.g cast will cast to a given datatype in the AST.
- Value lists e.g `... IN (1,2,3)`. Not the same as array.

## Types of changes

What types of changes does your code introduce to BinaryDefense.FSharp.Analyzers?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
